### PR TITLE
build(Dockerfile): Optimize the Docker build process and add a non-ro…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,13 @@ COPY go.mod go.sum ./
 # Download dependencies
 RUN go mod download
 
-# Copy source code
-COPY . .
+# Copy only necessary source code directories instead of everything
+COPY client/ ./client/
+COPY common/ ./common/
+COPY discovery/ ./discovery/
+COPY server/ ./server/
+COPY examples/ ./examples/
+COPY client.go server.go ./
 
 # Build HTTP server to temporary directory
 RUN mkdir -p /tmp/build && go build -o /tmp/build/server examples/http/server/main.go
@@ -24,6 +29,10 @@ FROM golang:1.24-alpine
 
 # Install runtime dependencies
 RUN apk add --no-cache wrk bash curl
+
+# Create a non-root user and group
+RUN addgroup -g 1001 appuser && \
+    adduser -S -u 1001 -G appuser appuser
 
 # Set working directory
 WORKDIR /app
@@ -38,8 +47,12 @@ COPY test/wrk/http.lua /app/http.lua
 # Use sed to fix line ending issues (handle Windows CRLF)
 RUN sed -i 's/\r$//' /app/test.sh
 
-# Set script permissions
-RUN chmod +x /app/test.sh
+# Set proper permissions for the application files
+RUN chown -R appuser:appuser /app && \
+    chmod +x /app/test.sh /app/server
+
+# Switch to non-root user
+USER appuser
 
 # Expose port
 EXPOSE 3232

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,11 +27,9 @@ RUN mkdir -p /tmp/build && go build -o /tmp/build/server examples/http/server/ma
 # Create final runtime image
 FROM golang:1.24-alpine
 
-# Install runtime dependencies
-RUN apk add --no-cache wrk bash curl
-
-# Create a non-root user and group
-RUN addgroup -g 1001 appuser && \
+# Install runtime dependencies and create non-root user
+RUN apk add --no-cache wrk bash curl && \
+    addgroup -g 1001 appuser && \
     adduser -S -u 1001 -G appuser appuser
 
 # Set working directory


### PR DESCRIPTION
…ot user

- Only copy the necessary source code directories instead of the entire content to reduce the build context size
- Add the non-root user appuser to enhance security Set the correct file permissions and switch to the running user
- Improve build and runtime security while maintaining the original functionality unchanged